### PR TITLE
Remove config.noScaleUp, is deprecated

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -83,9 +83,6 @@ config {
   sendCacheHeaders = 1
   uniqueLinkVars = 1
 
-  // Disable image upscaling
-  noScaleUp = 1
-
   // Compression and concatenation of CSS and JS Files
   compressCss = 0
   compressJs = 0


### PR DESCRIPTION
Using this setting config.noScaleUp will trigger a deprecation log entry. It will work until it get’s removed in TYPO3 v9.

https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/8.5/Deprecation-78134-DeprecateTyposcriptOptionConfignoScaleUp.html