### PR TITLE
[TASK] Replace f:cObject with the new f:record ViewHelper

### DIFF
--- a/Resources/Private/PageView/Partials/Content.fluid.html
+++ b/Resources/Private/PageView/Partials/Content.fluid.html
@@ -1,7 +1,3 @@
 <f:for each="{records}" as="record">
-    <f:cObject
-        typoscriptObjectPath="{record.mainType}"
-        data="{record}"
-        table="{record.mainType}"
-    />
+    <f:render.record record="{record}" />
 </f:for>

--- a/Resources/Private/PageView/Partials/Stage.fluid.html
+++ b/Resources/Private/PageView/Partials/Stage.fluid.html
@@ -1,9 +1,5 @@
 <f:for each="{content.stage.records}" as="record">
     <div class="container">
-        <f:cObject
-            typoscriptObjectPath="{record.mainType}"
-            data="{record}"
-            table="{record.mainType}"
-        />
+        <f:render.record record="{record}" />
     </div>
 </f:for>


### PR DESCRIPTION
Switch to the new `f:render.record` ViewHelper for content rendering.

Releases: main
References: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1563