### PR TITLE
[BUGFIX] Fix wrong type for imagewidth in example data

### DIFF
--- a/Initialisation/data.xml
+++ b/Initialisation/data.xml
@@ -1755,7 +1755,7 @@
 				<field index="image" type="integer">1</field>
 				<field index="assets" type="integer">0</field>
 				<field index="imagewidth" type="integer">250</field>
-				<field index="imageheight" type="integer">0</field>
+				<field index="imageheight" type="NULL"></field>
 				<field index="imageorient" type="integer">17</field>
 				<field index="imageborder" type="integer">0</field>
 				<field index="image_zoom" type="integer">0</field>
@@ -1839,7 +1839,7 @@
 				<field index="image" type="integer">1</field>
 				<field index="assets" type="integer">0</field>
 				<field index="imagewidth" type="integer">250</field>
-				<field index="imageheight" type="integer">0</field>
+				<field index="imageheight" type="NULL"></field>
 				<field index="imageorient" type="integer">18</field>
 				<field index="imageborder" type="integer">0</field>
 				<field index="image_zoom" type="integer">0</field>
@@ -2044,7 +2044,7 @@
 				<field index="image" type="integer">1</field>
 				<field index="assets" type="integer">0</field>
 				<field index="imagewidth" type="integer">250</field>
-				<field index="imageheight" type="integer">0</field>
+				<field index="imageheight" type="NULL"></field>
 				<field index="imageorient" type="integer">0</field>
 				<field index="imageborder" type="integer">0</field>
 				<field index="image_zoom" type="integer">0</field>


### PR DESCRIPTION
After import the data `imagewidth` in `textpic` elements is not `0` as
expected but `1` in database.
Due to that value, `width` and `height` of rendered image in frontend is `1`.
No image visible.
In backend the checkbox "Set value" is active. On saving the element
after field reset of `imagewidth` a min value `1` is set every time.
Setting the `imagewidth` for the `textpic` elements to `type=NULL` in
the `data.xml` fix that issue and images visible in frontend. 
Checkbox "Set value" is also not active.