### PR TITLE
[TASK] Small adjustments for content-block elements config

### DIFF
--- a/ContentBlocks/ContentElements/carousel/config.yaml
+++ b/ContentBlocks/ContentElements/carousel/config.yaml
@@ -2,7 +2,6 @@ name: site-package/carousel
 typeName: site_package_carousel
 group: site_package
 prefixFields: true
-prefixType: full
 fields:
   - identifier: carousel_items
     type: Collection

--- a/ContentBlocks/ContentElements/jumbotron/config.yaml
+++ b/ContentBlocks/ContentElements/jumbotron/config.yaml
@@ -2,7 +2,7 @@ name: site-package/jumbotron
 typeName: site_package_jumbotron
 group: site_package
 prefixFields: true
-prefixType: full
+priority: 10
 fields:
   -
     identifier: header


### PR DESCRIPTION
* remove `prefixType; full` because is the default value
*  add example setting `priority` which controls the ordering in new content element wizard