### PR TITLE
[TASK] Use new `page` type to set page uid in settings

### DIFF
--- a/Configuration/Sets/SitePackage/settings.definitions.yaml
+++ b/Configuration/Sets/SitePackage/settings.definitions.yaml
@@ -41,8 +41,8 @@ settings:
     default: 'EXT:site_package/Resources/Public/Icons/favicon.ico'
 
   SitePackage.footerMenuRoot:
-      label: 'Footer menu root uid'
+      label: 'Footer menu root page uid'
       description: 'The subpages of this page are displayed in the footer'
       category: SitePackage.menus
-      type: int
+      type: page
       default: 2


### PR DESCRIPTION
As described [here in TYPO3 documentation](https://docs.typo3.org/permalink/t3coreapi:confval-site-setting-type-page) I changed the type for the footer menu page id setting.