### PR TITLE
[BUGFIX] Add content_block dependency also in `ext_emconf.php`

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -10,6 +10,7 @@ $EM_CONF[$_EXTKEY] = [
             "typo3" => "14.0.0-14.3.99",
             "fluid_styled_content" => "14.0.0-14.3.99",
             "rte_ckeditor" => "14.0.0-14.3.99",
+            "content_blocks" => "2.0.0-2.99.99",
         ],
         "conflicts" => [],
     ],


### PR DESCRIPTION
Already set in `composer.json`. Dependencies should not differ in `ext_emconf.php` and `composer.json`.