### PR TITLE
[TASK] Use new `render.contentArea` ViewHelper in subpage template

### DIFF
--- a/Resources/Private/Templates/Pages/Default.fluid.html
+++ b/Resources/Private/Templates/Pages/Default.fluid.html
@@ -4,7 +4,7 @@
     <f:render partial="Stage" arguments="{_all}"/>
 
     <div class="container">
-        <f:render partial="Content" arguments="{records: content.main.records}"/>
+        <f:render.contentArea contentArea="{content.main}"/>
     </div>
 
 </f:section>

--- a/Resources/Private/Templates/Pages/Subpage.fluid.html
+++ b/Resources/Private/Templates/Pages/Subpage.fluid.html
@@ -7,10 +7,10 @@
     <div class="container">
         <div class="row">
             <div class="col-md-8">
-                <f:render partial="Content" arguments="{records: content.main.records}"/>
+                <f:render.contentArea contentArea="{content.main}"/>
             </div>
             <div class="col-md-4">
-                <f:render partial="Content" arguments="{records: content.sidebar.records}"/>
+                <f:render.contentArea contentArea="{content.sidebar}"/>
             </div>
         </div>
     </div>

--- a/Resources/Private/Templates/Partials/Content.fluid.html
+++ b/Resources/Private/Templates/Partials/Content.fluid.html
@@ -1,3 +1,0 @@
-<f:for each="{records}" as="record">
-    <f:render.record record="{record}" />
-</f:for>


### PR DESCRIPTION
There is a new ViewHelper to render a whole `contentArea`. That's a new simple method to just rendering all content in a content area.
I used this in the `subpage` template without the content partial. Just using the new ViewHelper.
The `default` template still using the content partial and set the records a argument.
Now we have both examples for simple content rendering in a site-package. 

See https://docs.typo3.org/permalink/changelog:feature-108726-1769071158 for details