### PR TITLE
[FEATURE] Add example for allowed and disallowed ctypes in colPos

### DIFF
--- a/Configuration/Sets/SitePackage/PageTsConfig/BackendLayouts/default.tsconfig
+++ b/Configuration/Sets/SitePackage/PageTsConfig/BackendLayouts/default.tsconfig
@@ -18,6 +18,7 @@ mod {
                                         colPos = 1
                                         identifier = stage
                                         slideMode = slide
+                                        allowedContentTypes = site_package_jumbotron,text
                                     }
                                 }
                             }
@@ -27,6 +28,7 @@ mod {
                                         name = LLL:site_package.backend.layouts:column.normal
                                         colPos = 0
                                         identifier = main
+                                        disallowedContentTypes = site_package_jumbotron
                                     }
                                 }
                             }


### PR DESCRIPTION
Add an example to allow or disallow `CTypes` in `colPos` in backend layout configuration.

https://docs.typo3.org/permalink/changelog:feature-108623-1768315053