### PR TITLE
[BUGFIX] Set proper relationship for files in carousel element

### DIFF
--- a/ContentBlocks/ContentElements/carousel/config.yaml
+++ b/ContentBlocks/ContentElements/carousel/config.yaml
@@ -14,7 +14,7 @@ fields:
         type: File
         allowed: common-image-types
         minitems: 1
-        relationship: manyToOne
+        relationship: oneToOne
       - identifier: header
         type: Text
       - identifier: description


### PR DESCRIPTION
Fix error after check of content-blocks elemenets config with the new linter.

References: https://github.com/TYPO3-Documentation/site_package/issues/87