### PR TITLE
[BUGFIX] Provide variables to main section

### DIFF
--- a/Resources/Private/Templates/Layouts/PageLayout.fluid.html
+++ b/Resources/Private/Templates/Layouts/PageLayout.fluid.html
@@ -8,7 +8,7 @@
 />
 <main>
     <f:render partial="Header" arguments="{_all}" />
-    <f:render section="Main" />
+    <f:render section="Main" arguments="{_all}" />
     <f:render partial="Footer" arguments="{_all}" />
 </main>
 <f:asset.script


### PR DESCRIPTION
Even though this currently works because of a Fluid bug, it is best practice to provide the variables to sections since they (usually) have their own variable scope.

See: https://github.com/TYPO3/Fluid/issues/1356